### PR TITLE
Use gh token for download public repo as well

### DIFF
--- a/actions/download-spctl/action.yaml
+++ b/actions/download-spctl/action.yaml
@@ -55,12 +55,7 @@ runs:
           local REPO="$1"
           local TAG_VERSION="$2"
 
-          if [ "${{ inputs.repository }}" = "public" ]; then
-            fetch --repo="https://github.com/$OWNER/$REPO" --tag="$TAG_VERSION" --release-asset="spctl-linux-x64" ./
-          else
-            fetch --repo="https://github.com/$OWNER/$REPO" --tag="$TAG_VERSION" --release-asset="spctl-linux-x64" --github-oauth-token="$GH_TOKEN" ./
-          fi
-
+          fetch --repo="https://github.com/$OWNER/$REPO" --tag="$TAG_VERSION" --release-asset="spctl-linux-x64" --github-oauth-token="$GH_TOKEN" ./
         }
 
         REPO=$([[ "${{ inputs.repository }}" = "public" ]] && echo "ctl" || echo "spctl")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the asset download process for consistent behavior, ensuring a uniform approach regardless of repository type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->