### PR TITLE
fix(update-argo-vm): restrict ARGO_SP_ENV assignment to only 'mainnet' target

### DIFF
--- a/actions/update-argo-vm/action.yaml
+++ b/actions/update-argo-vm/action.yaml
@@ -47,7 +47,7 @@ runs:
         fi
         echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
-        if [ "${{ inputs.target }}" == "testnet" ] || [ "${{ inputs.target }}" == "mainnet" ]; then
+        if [ "${{ inputs.target }}" == "mainnet" ]; then
           ARGO_SP_ENV=main
         else
           ARGO_SP_ENV=${{ inputs.target }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated environment variable mapping so that "testnet" is no longer treated as "main". Now, only "mainnet" maps to "main", while other values (including "testnet") retain their original value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->