### PR TITLE
fix(update-argocd): correct cluster assignments for testnet and mainnet targets

### DIFF
--- a/actions/update-argocd/action.yaml
+++ b/actions/update-argocd/action.yaml
@@ -59,9 +59,9 @@ runs:
         elif [ "${{ inputs.target }}" == "stage" ]; then
           CLUSTER=zen/staging
         elif [ "${{ inputs.target }}" == "testnet" ]; then
-          CLUSTER=zev/testnet
+          CLUSTER=zen/testnet
         elif [ "${{ inputs.target }}" == "mainnet" ]; then
-          CLUSTER=zev/mainnet
+          CLUSTER=zen/mainnet
         fi
 
         echo "CLUSTER=$CLUSTER" >> $GITHUB_ENV


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster path assignments for "testnet" and "mainnet" targets to use the correct prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->