### PR TITLE
feat(create-workflows/action.yaml): remove required storage_offer inp…

### DIFF
--- a/actions/create-workflows/action.yaml
+++ b/actions/create-workflows/action.yaml
@@ -18,9 +18,6 @@ inputs:
   data:
     description: Data offer number (with or without slot) or path to data resource file, separated by semicolon (e.g., "offerId,slotId;offerId;./data-settings.json")
     default: ''
-  storage_offer:
-    description: Storage offer number
-    required: true
   previous_orders:
     description: Previous order numbers to cancel, separated by comma (eg. 100,102)
   min_rent_minutes:
@@ -74,10 +71,10 @@ runs:
         if [ -n "${{ inputs.solution_configuration }}" ]; then
           # Split inputs.solution_configuration into an array using a comma as a separator
           IFS=',' read -ra config_items <<< "${{ inputs.solution_configuration }}"
-          
+
           # Split inputs.tee_offers into an array using a comma as a separator
           IFS=',' read -ra tee_items <<< "${{ inputs.tee_offers }}"
-          
+
           # If multiple configurations provided, count must match tee_offers count
           if [ ${#config_items[@]} -gt 1 ]; then
             if [ ${#config_items[@]} -ne ${#tee_items[@]} ]; then
@@ -123,7 +120,7 @@ runs:
 
         for i in "${!teeOfferIds[@]}"; do
           teeOffer="${teeOfferIds[$i]}"
-          
+
           COMMAND="./spctl workflows create --tee $teeOffer"
 
           if [ -n "${{ inputs.base_image }}" ]; then
@@ -151,7 +148,7 @@ runs:
             COMMAND="$COMMAND --data $item"
           done
 
-          COMMAND="$COMMAND --storage ${{ inputs.storage_offer }} --orders-limit 10000 --min-rent-minutes ${{ inputs.min_rent_minutes }} --config ${{ inputs.spctl_config_file }} > workflow_result.txt"
+          COMMAND="$COMMAND --orders-limit 10000 --min-rent-minutes ${{ inputs.min_rent_minutes }} --config ${{ inputs.spctl_config_file }} > workflow_result.txt"
 
           echo "COMMAND=$COMMAND"
           set +e
@@ -173,7 +170,7 @@ runs:
             exit 1
           fi
 
-          ORDER_ID=$(cat workflow_result.txt | grep -oP '\["\K\d+(?="\])') 
+          ORDER_ID=$(cat workflow_result.txt | grep -oP '\["\K\d+(?="\])')
 
           orderIds+=($ORDER_ID)
         done

--- a/actions/run-tunnel-server/action.yaml
+++ b/actions/run-tunnel-server/action.yaml
@@ -105,7 +105,7 @@ runs:
 
     - name: Create tunnel-server-order workflows
       id: create-workflows
-      uses: Super-Protocol/sp-build-tools/actions/create-workflows@SP-6909
+      uses: Super-Protocol/sp-build-tools/actions/create-workflows@v1
       with:
         spctl_config_file: ${{ inputs.spctl_config_file }}
         tee_offers: ${{ inputs.tee_offers }}

--- a/actions/run-tunnel-server/action.yaml
+++ b/actions/run-tunnel-server/action.yaml
@@ -79,21 +79,6 @@ runs:
         fi
         echo "TUNNEL_SERVER_OFFER=$TUNNEL_SERVER_OFFER" >> $GITHUB_ENV
 
-    - name: Set storage offer
-      shell: bash
-      run: |
-        if [ "${{ inputs.target }}" == "develop" ]; then
-          STORAGE_OFFER=39
-        elif [ "${{ inputs.target }}" == "stage" ]; then
-          STORAGE_OFFER=38
-        elif [ "${{ inputs.target }}" == "testnet" ]; then
-          STORAGE_OFFER=48
-        elif [ "${{ inputs.target }}" == "mainnet" ]; then
-          STORAGE_OFFER=47
-        fi
-
-        echo "STORAGE_OFFER=$STORAGE_OFFER" >> $GITHUB_ENV
-
     - name: Prepare working directory
       shell: bash
       run: |
@@ -120,14 +105,13 @@ runs:
 
     - name: Create tunnel-server-order workflows
       id: create-workflows
-      uses: Super-Protocol/sp-build-tools/actions/create-workflows@v1
+      uses: Super-Protocol/sp-build-tools/actions/create-workflows@SP-6909
       with:
         spctl_config_file: ${{ inputs.spctl_config_file }}
         tee_offers: ${{ inputs.tee_offers }}
         base_image: ${{ env.BASE_IMAGE_OFFER }}
         solution: ${{ env.TUNNEL_SERVER_OFFER }}
         data: ${{ steps.upload-data-file.outputs.resource }}
-        storage_offer: ${{ env.STORAGE_OFFER }}
         previous_orders: ${{ inputs.previous_orders }}
         min_rent_minutes: ${{ inputs.min_rent_minutes }}
 


### PR DESCRIPTION
…ut and clean up whitespace (SP-6909)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the storage_offer input from workflow creation; workflows are now created without a storage parameter.
  * Removed the step that computed and exported a storage offer, simplifying workflow setup.
  * Updated references to a newer version of the workflow creation action.
  * No changes to other inputs, validation, solution configuration, or order-id handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->